### PR TITLE
Update Makefile to install into DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ $(TARGET): discord.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^
 
 install: $(TARGET)
-	install -m=755 $(TARGET) /usr/lib64/bitlbee
+	install -Dm=755 $(TARGET) "$(DESTDIR)/usr/lib64/bitlbee/$(TARGET)"
 
 clean:
 	rm -rf $(TARGET) *.o


### PR DESCRIPTION
Updates the Makefile to make it possible to install bitlbee-discord into the specified `DESTDIR`, defaulting to /usr/lib64/bitlbee.

Makes it possible to create Arch Linux PKGBUILDs.