### PR TITLE
fix for error when displaying username of a renamed user

### DIFF
--- a/src/discord-handlers.c
+++ b/src/discord-handlers.c
@@ -411,7 +411,7 @@ static void discord_prepare_message(struct im_connection *ic,
         json_value *uinfo = mentions->u.array.values[midx];
         gchar *uname = discord_canonize_name(json_o_str(uinfo, "username"));
         gchar *newmsg = NULL;
-        gchar *idstr = g_strdup_printf("<@%s>", json_o_str(uinfo, "id"));
+        gchar *idstr = g_strdup_printf("<@!?%s>", json_o_str(uinfo, "id"));
         gchar *unstr = g_strdup_printf("@%s", uname);
         GRegex *regex = g_regex_new(idstr, 0, 0, NULL);
         newmsg = g_regex_replace_literal(regex, msg, -1, 0,


### PR DESCRIPTION
A somewhat new feature to discord allows users the option to rename themselves on a server by server basis.
When a user using the web or desktop app mentions a renamed user a ! is prepended to their user id and looks something like this (via bitlbee)
```<@!123456789> test too```
after adjusting the regex pattern it shows the username thats linked to the user's id (not the renamed nick)
```@mumixam test too```

when desktop and webapp would display
```@renamed test too```

This may not the ideal fix you want but its alot better than a big integer.
This bug was found and fixed by a member of beecord