### PR TITLE
Use HTTPS instead of HTTP

### DIFF
--- a/src/discord-http.c
+++ b/src/discord-http.c
@@ -48,7 +48,7 @@ static void discord_http_get(struct im_connection *ic, const char *api_path,
                   set_getstr(&ic->acc->set, "host"),
                   dd->token);
 
-  (void) http_dorequest(set_getstr(&ic->acc->set, "host"), 80, 0,
+  (void) http_dorequest(set_getstr(&ic->acc->set, "host"), 443, 1,
                         request->str, cb_func, data);
   g_string_free(request, TRUE);
 }
@@ -351,7 +351,7 @@ void discord_http_send_msg(struct im_connection *ic, const char *id,
                   content->len,
                   content->str);
 
-  (void) http_dorequest(set_getstr(&ic->acc->set, "host"), 80, 0,
+  (void) http_dorequest(set_getstr(&ic->acc->set, "host"), 443, 1,
                                    request->str, discord_http_send_msg_cb, ic);
 
   g_string_free(content, TRUE);
@@ -377,7 +377,7 @@ void discord_http_send_ack(struct im_connection *ic, const char *channel_id,
                   set_getstr(&ic->acc->set, "host"),
                   dd->token);
 
-  (void) http_dorequest(set_getstr(&ic->acc->set, "host"), 80, 0,
+  (void) http_dorequest(set_getstr(&ic->acc->set, "host"), 443, 1,
                                    request->str, discord_http_noop_cb,
                                    NULL);
 
@@ -404,7 +404,7 @@ void discord_http_mfa_auth(struct im_connection *ic, const char *msg)
                   auth->len,
                   auth->str);
 
-  (void) http_dorequest(set_getstr(&ic->acc->set, "host"), 80, 0,
+  (void) http_dorequest(set_getstr(&ic->acc->set, "host"), 443, 1,
                                    request->str, discord_http_mfa_cb,
                                    ic);
 
@@ -432,7 +432,7 @@ void discord_http_login(account_t *acc)
                   jlogin->len,
                   jlogin->str);
 
-  (void) http_dorequest(set_getstr(&acc->set, "host"), 80, 0,
+  (void) http_dorequest(set_getstr(&acc->set, "host"), 443, 1,
                                    request->str, discord_http_login_cb,
                                    acc->ic);
 
@@ -500,7 +500,7 @@ void discord_http_create_and_send_msg(struct im_connection *ic,
   casm_data *cd = g_new0(casm_data, 1);
   cd->ic = ic;
   cd->msg = g_strdup(msg);
-  (void) http_dorequest(set_getstr(&ic->acc->set, "host"), 80, 0,
+  (void) http_dorequest(set_getstr(&ic->acc->set, "host"), 443, 1,
                                    request->str, discord_http_casm_cb, cd);
 
   g_string_free(content, TRUE);


### PR DESCRIPTION
When I first tried this plugin I was unable to connect to Discord.  There weren't any error messages.  After playing around with cURL and Wireshark i found something interesting.

    $ curl -q -X POST -d '{}' -H Content-Type:application/json http://discordapp.com/api/auth/login
    <html>
    <head><title>301 Moved Permanently</title></head>
    <body bgcolor="white">
    <center><h1>301 Moved Permanently</h1></center>
    <hr><center>nginx</center>
    </body>
    </html>
    $ curl -qL -X POST -d '{}' -H Content-Type:application/json http://discordapp.com/api/auth/login
    <!DOCTYPE html>
    <html lang=en>
      <meta charset=utf-8>
      <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
      <title>Error 411 (Length Required)!!1</title>
      <style>
        *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
      </style>
      <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
      <p><b>411.</b> <ins>That’s an error.</ins>
      <p>POST requests require a <code>Content-length</code> header.  <ins>That’s all we know.</ins>

Wireshark shows that there was a `Content-Length` header in the original HTTP request.  However when we use HTTPS to be begin with, everything works as expected.

    $ curl -qL -X POST -d '{}' -H Content-Type:application/json https://discordapp.com/api/auth/login
    {"email": ["This field is required."], "password": ["This field is required."]}
    $ echo ... | jq -R '{"email":"...","password":.}' | curl -qL -X POST -d @- -H Content-Type:application/json https://discordapp.com/api/auth/login
    {"token": "..."}

This patch makes this plugin use HTTPS and allows this plugin to circumvent the above error.  With this I can successfully connect to Discord.

As a byproduct it also avoids extra round trips caused by the redirects.  Furthermore it doesn't send the login credentials in plaintext anymore!
