### PR TITLE
Change bitlbee includes from <bitlbee/*.h> to <*.h>

### DIFF
--- a/src/discord-handlers.c
+++ b/src/discord-handlers.c
@@ -16,7 +16,7 @@
  */
 
 #include <config.h>
-#include <bitlbee/json_util.h>
+#include <json_util.h>
 
 #include "discord-util.h"
 #include "discord-handlers.h"

--- a/src/discord-handlers.h
+++ b/src/discord-handlers.h
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "discord.h"
-#include <bitlbee/json.h>
+#include <json.h>
 
 typedef enum {
   ACTION_CREATE,

--- a/src/discord-http.c
+++ b/src/discord-http.c
@@ -15,9 +15,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <config.h>
-#include <bitlbee/http_client.h>
-#include <bitlbee/json.h>
-#include <bitlbee/json_util.h>
+#include <http_client.h>
+#include <json.h>
+#include <json_util.h>
 
 #include "discord.h"
 #include "discord-http.h"

--- a/src/discord-http.h
+++ b/src/discord-http.h
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <bitlbee/bitlbee.h>
+#include <bitlbee.h>
 
 void discord_http_send_msg(struct im_connection *ic, const char *id,
                            const char *msg);

--- a/src/discord-util.c
+++ b/src/discord-util.c
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "discord-util.h"
-#include <bitlbee/http_client.h>
+#include <http_client.h>
 
 void discord_debug(char *format, ...)
 {

--- a/src/discord-websockets.c
+++ b/src/discord-websockets.c
@@ -15,8 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <config.h>
-#include <bitlbee/ssl_client.h>
-#include <bitlbee/events.h>
+#include <ssl_client.h>
+#include <events.h>
 
 #include "discord-websockets.h"
 #include "discord-handlers.h"

--- a/src/discord.h
+++ b/src/discord.h
@@ -17,7 +17,7 @@
 #ifndef __DISCORD_H
 #define __DISCORD_H
 
-#include <bitlbee/bitlbee.h>
+#include <bitlbee.h>
 
 #define DISCORD_HOST "discordapp.com"
 #define DEFAULT_KEEPALIVE_INTERVAL 30000


### PR DESCRIPTION
This is unfortunate (given the somewhat generic header names) but that's how it should be used to support non-system-wide installs.

With the previous include set up, building this plugin only worked when bitlbee's headers were in `/usr/include/bitlbee`, because `/usr/include` is in the default include path and the `-I/usr/include/bitlbee` is unused (because `/usr/include/bitlbee/bitlbee` does not exist)

Likely related to #77