### PR TITLE
Makefile.am: add -no-undefined for cygwin

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -24,6 +24,7 @@ discord_la_CFLAGS  = \
 discord_la_LDFLAGS = \
 	-module \
 	-avoid-version \
+	-no-undefined \
 	$(GLIB_LIBS)
 
 discord_la_SOURCES = \


### PR DESCRIPTION
Quoting https://cygwin.com/ml/cygwin/2013-07/msg00421.html

>despite popular misconception, this flag is harmless on non-PE targets

This also depends on changes on the bitlbee side to be able to link to
bitlbee itself, see bitlbee commit 54b2a367 (version string
3.5.1+20170513+develop+16-g54b2a367-git)