### PR TITLE
Make server_prefix_len truncate by utf8 characters instead of bytes

### DIFF
--- a/src/discord-handlers.c
+++ b/src/discord-handlers.c
@@ -236,7 +236,7 @@ void discord_handle_channel(struct im_connection *ic, json_value *cinfo,
           if (plen < 0) {
             prefix = g_strdup(sinfo->name);
           } else {
-            prefix = g_strndup(sinfo->name, plen);
+            prefix = discord_utf8_strndup(sinfo->name, plen);
           }
           fullname = g_strconcat(prefix, ".", name, NULL);
         }

--- a/src/discord-util.c
+++ b/src/discord-util.c
@@ -346,3 +346,12 @@ char *discord_escape_string(const char *msg)
 
   return emsg;
 }
+
+char *discord_utf8_strndup(const char *str, size_t n)
+{
+  if (g_utf8_strlen(str, -1) <= n) {
+    return g_strdup(str);
+  }
+
+  return g_strndup(str, g_utf8_offset_to_pointer(str, n) - str);
+}

--- a/src/discord-util.h
+++ b/src/discord-util.h
@@ -42,3 +42,4 @@ void free_gw_data(gw_data *gw);
 char *discord_canonize_name(const char *name);
 char *discord_escape_string(const char *msg);
 void discord_debug(char *format, ...);
+char *discord_utf8_strndup(const char *str, size_t n);


### PR DESCRIPTION
Fixes issues with invalid utf8 in servers that start their names with
unicode characters (like emoji)

Oddly enough there's no glib function for this, and bitlbee's
truncate_utf8() does the opposite of what we need to do here (truncates
by bytes instead of characters and ensures those bytes are valid utf8)

------

Fixes #85 

I should probably figure out what to do to avoid writing invalid utf8 to the config in the first place (like some sort of write-time validation? but what can i do if it's not valid?), but that's harder than fixing this side.