### PR TITLE
Revert "Makefile.am: add -no-undefined for cygwin"

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -24,7 +24,6 @@ discord_la_CFLAGS  = \
 discord_la_LDFLAGS = \
 	-module \
 	-avoid-version \
-	-no-undefined \
 	$(GLIB_LIBS)
 
 discord_la_SOURCES = \


### PR DESCRIPTION
This reverts commit 84315b6bfc5fdc5fe631f29d85113b52abb2936a.

Turns out it wasn't harmless, and it breaks mac OS. Instead of adding
platform checks here, this flag is now included in the cygwin-specific
parts of the bitlbee pkg-config file, as of bitlbee commit b9c10a1a
(version string 3.5.1+20170529+develop+18-gb9c10a1a-git)

-----

Sorry for the noise.