### PR TITLE
discord-websockets: fix some warnings

### DIFF
--- a/src/discord-handlers.c
+++ b/src/discord-handlers.c
@@ -614,7 +614,7 @@ void discord_parse_message(struct im_connection *ic, gchar *buf, guint64 size)
   discord_data *dd = ic->proto_data;
   json_value *js = json_parse((gchar*)buf, size);
 
-  discord_debug("<<< (%s) %s %"PRIu64"\n%s\n", dd->uname, __func__, size, buf);
+  discord_debug("<<< (%s) %s %"G_GUINT64_FORMAT"\n%s\n", dd->uname, __func__, size, buf);
 
   if (!js || js->type != json_object) {
     imcb_error(ic, "Failed to parse json reply.");

--- a/src/discord-websockets.c
+++ b/src/discord-websockets.c
@@ -64,11 +64,11 @@ static int discord_ws_send_payload(discord_data *dd, const char *pload,
     buf[1] = (char)psize | 0x80;
   } else if (psize > G_MAXUINT16) {
     guint64 esize = GUINT64_TO_BE(psize);
-    buf[1] = 127 | (char)0x80;
+    buf[1] = (gchar)(127 | 0x80);
     memcpy(buf + 2, &esize, sizeof(esize));
   } else {
     guint16 esize = GUINT16_TO_BE(psize);
-    buf[1] = 126 | (char)0x80;
+    buf[1] = (gchar)(126 | 0x80);
     memcpy(buf + 2, &esize, sizeof(esize));
   }
 

--- a/src/discord-websockets.c
+++ b/src/discord-websockets.c
@@ -44,7 +44,7 @@ static int discord_ws_send_payload(discord_data *dd, const char *pload,
   guchar mkey[4];
   gchar *mpload;
 
-  discord_debug(">>> (%s) %s %"PRIu64"\n%s\n", dd->uname, __func__, psize, pload);
+  discord_debug(">>> (%s) %s %"G_GUINT64_FORMAT"\n%s\n", dd->uname, __func__, psize, pload);
 
   random_bytes(mkey, sizeof(mkey));
   mpload = discord_ws_mask(mkey, pload, psize);

--- a/src/discord-websockets.c
+++ b/src/discord-websockets.c
@@ -64,11 +64,11 @@ static int discord_ws_send_payload(discord_data *dd, const char *pload,
     buf[1] = (char)psize | 0x80;
   } else if (psize > G_MAXUINT16) {
     guint64 esize = GUINT64_TO_BE(psize);
-    buf[1] = 127 | 0x80;
+    buf[1] = 127 | (char)0x80;
     memcpy(buf + 2, &esize, sizeof(esize));
   } else {
     guint16 esize = GUINT16_TO_BE(psize);
-    buf[1] = 126 | 0x80;
+    buf[1] = 126 | (char)0x80;
     memcpy(buf + 2, &esize, sizeof(esize));
   }
 
@@ -106,7 +106,7 @@ static gboolean discord_ws_writable(gpointer data, int source,
     if (dd->seq == 0) {
       g_string_printf(buf, "{\"op\":%d,\"d\":null}", OPCODE_HEARTBEAT);
     } else {
-      g_string_printf(buf, "{\"op\":%d,\"d\":%"PRIu64"}", OPCODE_HEARTBEAT,
+      g_string_printf(buf, "{\"op\":%d,\"d\":%"G_GUINT64_FORMAT"}", OPCODE_HEARTBEAT,
                       dd->seq);
     }
     discord_ws_send_payload(dd, buf->str, buf->len);


### PR DESCRIPTION
As discord_data.seq is a guint64, use G_GUINT64_FORMAT instead of
PRIu64. This fixes "warning: format specifies type 'unsigned long
long' but the argument has type 'guint64'".

The other two changes are supposed to fix "warning: implicit
conversion from 'int' to 'gchar' (aka 'char') changes value from 255
to -1". (I'm less sure about this change.)