### PR TITLE
Enable self messages

### DIFF
--- a/src/discord-handlers.c
+++ b/src/discord-handlers.c
@@ -509,9 +509,7 @@ static gboolean discord_prepare_message(struct im_connection *ic,
   }
 
   if (cinfo->type == CHANNEL_PRIVATE) {
-    if (is_self || g_strcmp0(author, cinfo->to.handle.name) == 0) {
-      posted = discord_post_message(cinfo, cinfo->to.handle.name, msg, is_self);
-    }
+    posted = discord_post_message(cinfo, cinfo->to.handle.name, msg, is_self);
   } else if (cinfo->type == CHANNEL_TEXT) {
     json_value *mentions = json_o_get(minfo, "mentions");
     if (mentions != NULL && mentions->type == json_array) {

--- a/src/discord-handlers.c
+++ b/src/discord-handlers.c
@@ -510,7 +510,7 @@ static gboolean discord_prepare_message(struct im_connection *ic,
 
   if (cinfo->type == CHANNEL_PRIVATE) {
     if (is_self || g_strcmp0(author, cinfo->to.handle.name) == 0) {
-      posted = discord_post_message(cinfo, author, msg, is_self);
+      posted = discord_post_message(cinfo, cinfo->to.handle.name, msg, is_self);
     }
   } else if (cinfo->type == CHANNEL_TEXT) {
     json_value *mentions = json_o_get(minfo, "mentions");

--- a/src/discord-http.c
+++ b/src/discord-http.c
@@ -434,7 +434,8 @@ void discord_http_send_msg(struct im_connection *ic, const char *id,
     emsg = nmsg;
   }
 
-  g_string_printf(content, "{\"content\":\"%s\"}", emsg);
+  g_string_printf(content, "{\"content\":\"%s\", \"nonce\":\"%s\"}",
+                  emsg, dd->nonce);
   g_free(emsg);
   g_string_printf(request, "POST /api/channels/%s/messages HTTP/1.1\r\n"
                   "Host: %s\r\n"

--- a/src/discord-util.c
+++ b/src/discord-util.c
@@ -100,6 +100,7 @@ void free_discord_data(discord_data *dd)
   g_slist_free_full(dd->servers, (GDestroyNotify)free_server_info);
 
   free_gw_data(dd->gateway);
+  g_free(dd->nonce);
   g_free(dd->token);
   g_free(dd->uname);
   g_free(dd->id);

--- a/src/discord.c
+++ b/src/discord.c
@@ -115,6 +115,10 @@ static void discord_login(account_t *acc)
   dd->keepalive_interval = DEFAULT_KEEPALIVE_INTERVAL;
   ic->proto_data = dd;
 
+  guchar nonce_bytes[16];
+  random_bytes(nonce_bytes, sizeof(nonce_bytes));
+  dd->nonce = g_base64_encode(nonce_bytes, sizeof(nonce_bytes));
+
   if (set_getstr(&ic->acc->set,"token_cache")) {
     discord_http_get_gateway(ic, set_getstr(&ic->acc->set,"token_cache"));
   } else {
@@ -214,7 +218,7 @@ static int discord_buddy_msg(struct im_connection *ic, char *to, char *msg,
   return 0;
 }
 
-static gboolean discord_is_self(struct im_connection *ic, const char *who)
+gboolean discord_is_self(struct im_connection *ic, const char *who)
 {
   discord_data *dd = ic->proto_data;
   return !g_strcmp0(dd->uname, who);

--- a/src/discord.h
+++ b/src/discord.h
@@ -49,6 +49,7 @@ typedef struct _discord_data {
   char     *token;
   char     *id;
   char     *uname;
+  char     *nonce;
   gw_data  *gateway;
   GSList   *servers;
   GSList   *pchannels;
@@ -100,5 +101,7 @@ typedef struct _user_info {
   channel_info         *voice_channel;
   bee_user_t           *user;
 } user_info;
+
+gboolean discord_is_self(struct im_connection *ic, const char *who);
 
 #endif //__DISCORD_H


### PR DESCRIPTION
Messages sent from another discord client will now appear as if you sent
them from Bitlbee.
    
See https://wiki.bitlbee.org/SelfMessages for more information about
this feature.