### PR TITLE
Fix login failure when no servers exist

### DIFF
--- a/src/discord-handlers.c
+++ b/src/discord-handlers.c
@@ -663,13 +663,17 @@ void discord_parse_message(struct im_connection *ic, gchar *buf, guint64 size)
 
     discord_add_global_server(ic);
     json_value *guilds = json_o_get(data, "guilds");
-    if (guilds != NULL && guilds->type == json_array) {
+    if (guilds != NULL && guilds->type == json_array &&
+        guilds->u.array.length > 0) {
       for (int gidx = 0; gidx < guilds->u.array.length; gidx++) {
         if (guilds->u.array.values[gidx]->type == json_object) {
           json_value *ginfo = guilds->u.array.values[gidx];
           discord_handle_server(ic, ginfo, ACTION_CREATE);
         }
       }
+    } else {
+      dd->state = WS_READY;
+      imcb_connected(ic);
     }
 
     json_value *pcs = json_o_get(data, "private_channels");


### PR DESCRIPTION
- Fix login failure when no servers exist
- ~~Send sync requests together
   The gateway will sometimes ignore two consecutive sync requests.~~

   ~~This makes sure to send only one request for all the servers that we
need to sync.~~

EDIT: Actually, the second issue isn't fixed at all, I'll have to investigate more
EDIT2: See #105 