### PR TITLE
Read all available data from the SSL buffer

### DIFF
--- a/src/discord-websockets.c
+++ b/src/discord-websockets.c
@@ -231,6 +231,7 @@ static gboolean discord_ws_in_cb(gpointer data, int source,
     if (read != len) {
         imcb_error(ic, "Failed to read data.");
         imc_logout(ic, TRUE);
+        g_free(rdata);
         return FALSE;
     }
 

--- a/src/discord-websockets.c
+++ b/src/discord-websockets.c
@@ -231,6 +231,7 @@ static gboolean discord_ws_in_cb(gpointer data, int source,
     if (read != len) {
         imcb_error(ic, "Failed to read data.");
         imc_logout(ic, TRUE);
+        return FALSE;
     }
 
     if (mask) {
@@ -243,7 +244,7 @@ static gboolean discord_ws_in_cb(gpointer data, int source,
     g_free(rdata);
   }
   if (ssl_pending(dd->ssl)) {
-    /* OpenSSL empties the TCP buffers completely but may keep some
+    /* The SSL library empties the TCP buffers completely but may keep some
        data in its internal buffers. select() won't see that, but
        ssl_pending() does. */
     return discord_ws_in_cb(data, source, cond);


### PR DESCRIPTION
We could end up in a situation where websocket messages would stay stuck
in the SSL buffer because we only read one at a time although the SSL
buffer can hold more.

This addresses the sync issues I mentioned in #104 