### PR TITLE
Group DMs

### DIFF
--- a/src/discord-handlers.c
+++ b/src/discord-handlers.c
@@ -374,12 +374,12 @@ void discord_handle_channel(struct im_connection *ic, json_value *cinfo,
 
 static void discord_add_global_server(struct im_connection *ic) {
   discord_data *dd = ic->proto_data;
-    server_info *sinfo = g_new0(server_info, 1);
+  server_info *sinfo = g_new0(server_info, 1);
 
-    sinfo->name = g_strdup("_global");
-    sinfo->id = g_strdup(GLOBAL_SERVER_ID);
-    sinfo->ic = ic;
-    dd->servers = g_slist_prepend(dd->servers, sinfo);
+  sinfo->name = g_strdup("_global");
+  sinfo->id = g_strdup(GLOBAL_SERVER_ID);
+  sinfo->ic = ic;
+  dd->servers = g_slist_prepend(dd->servers, sinfo);
 }
 
 static void discord_handle_server(struct im_connection *ic, json_value *sinfo,

--- a/src/discord-handlers.c
+++ b/src/discord-handlers.c
@@ -415,10 +415,6 @@ void discord_handle_channel(struct im_connection *ic, json_value *cinfo,
         if (g_strcmp0(topic, cdata->to.channel.gc->topic) != 0) {
           imcb_chat_topic(cdata->to.channel.gc, "root", (char*)topic, 0);
         }
-      } else if (cdata->type == CHANNEL_GROUP_PRIVATE && cdata->to.group.gc != NULL) {
-        if (g_strcmp0(topic, cdata->to.group.gc->topic) != 0) {
-          imcb_chat_topic(cdata->to.group.gc, "root", (char*)topic, 0);
-        }
       }
     }
   }

--- a/src/discord.c
+++ b/src/discord.c
@@ -180,9 +180,6 @@ static struct groupchat *discord_chat_join(struct im_connection *ic,
     cinfo->to.channel.gc = gc;
   } else if (cinfo != NULL && cinfo->type == CHANNEL_GROUP_PRIVATE) {
     gc = imcb_chat_new(ic, cinfo->to.group.name);
-    if (cinfo->to.group.bci->topic != NULL) {
-      imcb_chat_topic(gc, "root", cinfo->to.group.bci->topic, 0);
-    }
 
     for (GSList *ul = cinfo->to.group.users; ul; ul = g_slist_next(ul)) {
       user_info *uinfo = ul->data;

--- a/src/discord.h
+++ b/src/discord.h
@@ -98,6 +98,13 @@ typedef struct _channel_info {
       char                 *name;
       struct im_connection *ic;
     } handle;
+    struct {
+      struct groupchat     *gc;
+      char                 *name;
+      bee_chat_info_t      *bci;
+      GSList               *users;
+      struct im_connection *ic;
+    } group;
   } to;
   channel_type         type;
   GSList *pinned;


### PR DESCRIPTION
Group names can change easily, so this uses the ID as the bitlbee room name. Use `chat list discord` to find them, they will not be joined automatically.

Not handled: add/remove users on a `CHANNEL_UPDATE` (is that even used for group dms? I have no idea)

See also #54