### PR TITLE
Fix use-after-free on OPCODE_RECONNECT/INVALID_SESSION

### DIFF
--- a/src/discord-handlers.c
+++ b/src/discord-handlers.c
@@ -740,7 +740,7 @@ void discord_handle_message(struct im_connection *ic, json_value *minfo,
   }
 }
 
-void discord_parse_message(struct im_connection *ic, gchar *buf, guint64 size)
+void discord_parse_message(struct im_connection *ic, gchar *buf, guint64 size, gboolean *disconnected)
 {
   discord_data *dd = ic->proto_data;
   json_value *js = json_parse((gchar*)buf, size);
@@ -750,6 +750,7 @@ void discord_parse_message(struct im_connection *ic, gchar *buf, guint64 size)
   if (!js || js->type != json_object) {
     imcb_error(ic, "Failed to parse json reply.");
     imc_logout(ic, TRUE);
+    *disconnected = TRUE;
     goto exit;
   }
 
@@ -783,9 +784,11 @@ void discord_parse_message(struct im_connection *ic, gchar *buf, guint64 size)
   } else if (op == OPCODE_RECONNECT) {
     imcb_log(ic, "Reconnect requested");
     imc_logout(ic, TRUE);
+    *disconnected = TRUE;
   } else if (op == OPCODE_INVALID_SESSION) {
     imcb_error(ic, "Invalid session, reconnecting");
     imc_logout(ic, TRUE);
+    *disconnected = TRUE;
   } else if (g_strcmp0(event, "READY") == 0) {
     dd->state = WS_ALMOST_READY;
     json_value *data = json_o_get(js, "d");

--- a/src/discord-handlers.h
+++ b/src/discord-handlers.h
@@ -27,4 +27,5 @@ void discord_handle_message(struct im_connection *ic, json_value *minfo,
                             handler_action action);
 void discord_handle_channel(struct im_connection *ic, json_value *cinfo,
                             const char *server_id, handler_action action);
-void discord_parse_message(struct im_connection *ic, gchar *buf, guint64 size, gboolean *disconnected);
+/* Returns TRUE if it called iwc_logout() */
+gboolean discord_parse_message(struct im_connection *ic, gchar *buf, guint64 size);

--- a/src/discord-handlers.h
+++ b/src/discord-handlers.h
@@ -27,4 +27,4 @@ void discord_handle_message(struct im_connection *ic, json_value *minfo,
                             handler_action action);
 void discord_handle_channel(struct im_connection *ic, json_value *cinfo,
                             const char *server_id, handler_action action);
-void discord_parse_message(struct im_connection *ic, gchar *buf, guint64 size);
+void discord_parse_message(struct im_connection *ic, gchar *buf, guint64 size, gboolean *disconnected);


### PR DESCRIPTION
I got a few segfaults during a recent Discord outage. Throwing Valgrind at it yielded:
```
[23:25:36] <<< ((null)) discord_parse_message 36
{"t":null,"s":null,"op":9,"d":false}

==20729== Invalid read of size 8
==20729==    at 0x8683E84: discord_ws_in_cb (discord-websockets.c:247)
==20729==    by 0x130FD0: ??? (in /usr/sbin/bitlbee)
==20729==    by 0x566359F: event_base_loop (in /usr/lib/x86_64-linux-gnu/libevent-2.0.so.5.1.9)
==20729==    by 0x130B4F: b_main_run (in /usr/sbin/bitlbee)
==20729==    by 0x11AD3C: main (in /usr/sbin/bitlbee)
==20729==  Address 0x80ff9e8 is 88 bytes inside a block of size 136 free'd
==20729==    at 0x4C2CDDB: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==20729==    by 0x867F2BC: discord_logout (discord.c:139)
==20729==    by 0x13D6D1: imc_logout (in /usr/sbin/bitlbee)
==20729==    by 0x8681191: discord_parse_message (discord-handlers.c:788)
==20729==    by 0x8683F38: discord_ws_in_cb (discord-websockets.c:243)
==20729==    by 0x130FD0: ??? (in /usr/sbin/bitlbee)
==20729==    by 0x566359F: event_base_loop (in /usr/lib/x86_64-linux-gnu/libevent-2.0.so.5.1.9)
==20729==    by 0x130B4F: b_main_run (in /usr/sbin/bitlbee)
==20729==    by 0x11AD3C: main (in /usr/sbin/bitlbee)
==20729==  Block was alloc'd at
==20729==    at 0x4C2DBC5: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==20729==    by 0x538FE60: g_malloc0 (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.5000.3)
==20729==    by 0x867F2EE: discord_login (discord.c:118)
==20729==    by 0x13AFFB: account_on (in /usr/sbin/bitlbee)
==20729==    by 0x12C70C: ??? (in /usr/sbin/bitlbee)
==20729==    by 0x12C929: cmd_identify_finish (in /usr/sbin/bitlbee)
==20729==    by 0x12CC1F: ??? (in /usr/sbin/bitlbee)
==20729==    by 0x11FFFE: irc_process (in /usr/sbin/bitlbee)
==20729==    by 0x11BBBE: bitlbee_io_current_client_read (in /usr/sbin/bitlbee)
==20729==    by 0x130FD0: ??? (in /usr/sbin/bitlbee)
==20729==    by 0x566359F: event_base_loop (in /usr/lib/x86_64-linux-gnu/libevent-2.0.so.5.1.9)
==20729==    by 0x130B4F: b_main_run (in /usr/sbin/bitlbee)
```

I believe this PR fixes it. Unfortunately, the downtime ended before I was able to figure it out, so I wasn't able to fully test it.