### PR TITLE
Tweak contrib/docker; fix permissions, enhance readme, change to ForkDaemon

### DIFF
--- a/README
+++ b/README
@@ -50,7 +50,9 @@ If your bitlbee's plugindir is in non-standard location you can specify it by
 calling ./configure with --with-plugindir=/path/to/plugindir option.
 
 You can also use the dockerfile from contrib/docker to build a docker container
-containing bitlbee + bitlbee-discord.
+containing bitlbee + bitlbee-discord. Use this command to run the container:
+
+  $ docker run -d -v /bitlbee/config:/var/lib/bitlbee -p 6667:6667 --name bitlbee <image>
 
 Usage
 -----

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,16 +1,17 @@
-FROM debian
+FROM debian:buster
 MAINTAINER Daniel da Silva <mail@danieldasilva.org>
 
 # Make & install
 RUN apt-get update
 RUN apt-get install bitlbee-dev bitlbee-libpurple bitlbee-plugin-otr git autoconf build-essential autoproject libtool glib2.0 glib2.0-dev -y
-RUN mkdir /data
 RUN cd tmp && git clone https://github.com/sm00th/bitlbee-discord.git && cd bitlbee-discord && ./autogen.sh && ./configure && make && make install
 
 # Bitlbee config
-VOLUME ["/data"]
 EXPOSE 6667
+VOLUME ["/var/lib/bitlbee"]
+COPY bitlbee.conf /etc/bitlbee/bitlbee.conf
+WORKDIR /
+RUN chown -R bitlbee /var/lib/bitlbee/
 
-ADD bitlbee.conf /etc/bitlbee/bitlbee.conf
+ENTRYPOINT chown -R bitlbee /var/lib/bitlbee && /usr/sbin/bitlbee -n -c /etc/bitlbee/bitlbee.conf
 
-ENTRYPOINT ["/usr/sbin/bitlbee", "-n", "-c", "/etc/bitlbee/bitlbee.conf"]

--- a/contrib/docker/bitlbee.conf
+++ b/contrib/docker/bitlbee.conf
@@ -16,14 +16,14 @@
 ##    child processes. This should be pretty safe and reliable to use instead
 ##    of inetd mode.
 ##
-RunMode = Daemon
+RunMode = ForkDaemon
 
 ## User:
 ## 
 ## If BitlBee is started by root as a daemon, it can drop root privileges,
 ## and change to the specified user.
 ##
-User = daemon
+User = bitlbee
 
 ## DaemonPort/DaemonInterface:
 ##
@@ -89,7 +89,7 @@ User = daemon
 ## Specify an alternative directory to store all the per-user configuration
 ## files. (.nicks/.accounts)
 ##
-ConfigDir = /data
+ConfigDir = /var/lib/bitlbee
 
 ## Ping settings
 ##


### PR DESCRIPTION
I had to fix some permissions problems that weren't obvious when I first started running it. I also added a line to the readme and switched bitlbee mode to the ForkDaemon, which is preferred as a crash in for one user doesn't crash the whole server.

