### PR TITLE
Fix crash when deleting a channel

### DIFF
--- a/src/discord.c
+++ b/src/discord.c
@@ -244,6 +244,17 @@ struct groupchat *discord_chat_do_join(struct im_connection *ic,
   return gc;
 }
 
+static void discord_chat_leave(struct groupchat *gc)
+{
+  channel_info *cinfo = gc->data;
+  server_info *sinfo = cinfo->to.channel.sinfo;
+  discord_data *dd = sinfo->ic->proto_data;
+  
+  sinfo->channels = g_slist_remove(sinfo->channels, cinfo);
+  dd->pchannels = g_slist_remove(dd->pchannels, cinfo);
+  free_channel_info(cinfo);
+}
+
 static int discord_buddy_msg(struct im_connection *ic, char *to, char *msg,
                              int flags)
 {
@@ -304,6 +315,7 @@ G_MODULE_EXPORT void init_plugin(void)
     .chat_msg = discord_chat_msg,
     .chat_list = discord_chat_list,
     .chat_join = discord_chat_join,
+    .chat_leave = discord_chat_leave,
     .buddy_msg = discord_buddy_msg,
     .handle_cmp = g_strcmp0,
     .handle_is_self = discord_is_self,

--- a/src/discord.c
+++ b/src/discord.c
@@ -247,12 +247,8 @@ struct groupchat *discord_chat_do_join(struct im_connection *ic,
 static void discord_chat_leave(struct groupchat *gc)
 {
   channel_info *cinfo = gc->data;
-  server_info *sinfo = cinfo->to.channel.sinfo;
-  discord_data *dd = sinfo->ic->proto_data;
-  
-  sinfo->channels = g_slist_remove(sinfo->channels, cinfo);
-  dd->pchannels = g_slist_remove(dd->pchannels, cinfo);
-  free_channel_info(cinfo);
+  imcb_chat_free(cinfo->to.channel.gc);
+  cinfo->to.channel.gc = NULL;
 }
 
 static int discord_buddy_msg(struct im_connection *ic, char *to, char *msg,


### PR DESCRIPTION
To reproduce:
- /part #general
- /msg &bitlbee channel #general del
- Wait a few minutes

Expected: I don't see that channel again

Actual:

```
[22:56:27] <<< (Alcaro) discord_parse_message 274
{"t":"PRESENCE_UPDATE","s":47,"op":0,"d":{"user":{"id":"313409368643338251"},"status":"online","roles":["280006158192869376","308737073496719362"],"nick":null,"guild_id":"161245277179609089","game":{"type":0,"timestamps":{"start":1524430585163},"name":"Warframe Launcher"}}}


Program received signal SIGSEGV, Segmentation fault.
0x00005555555700e9 in irc_channel_add_user ()
(gdb) bt
#0  0x00005555555700e9 in irc_channel_add_user ()
#1  0x000055555556cc5f in ?? ()
#2  0x0000555555587a74 in imcb_chat_add_buddy ()
#3  0x00007ffff478c05d in discord_handle_presence (ic=0x555555804c50, 
    pinfo=<optimized out>, server_id=<optimized out>) at discord-handlers.c:108
#4  0x00007ffff478ddb2 in discord_parse_message (ic=ic@entry=0x555555804c50, 
    buf=buf@entry=0x555555804f70 "{\"t\":\"PRESENCE_UPDATE\",\"s\":47,\"op\":0,\"d\":{\"user\":{\"id\":\"313409368643338251\"},\"status\":\"online\",\"roles\":[\"280006158192869376\",\"308737073496719362\"],\"nick\":null,\"guild_id\":\"161245277179609089\",\"game\":{\""..., size=size@entry=274)
    at discord-handlers.c:940
#5  0x00007ffff47906e9 in discord_ws_in_cb (data=0x555555804c50, source=12, 
    cond=B_EV_IO_READ) at discord-websockets.c:281
#6  0x000055555557cfd1 in ?? ()
#7  0x00007ffff73845a0 in event_base_loop ()
   from /usr/lib/x86_64-linux-gnu/libevent-2.0.so.5
#8  0x000055555557cb50 in b_main_run ()
#9  0x0000555555566d3d in main ()
(gdb) 
```
(plus 99% chance Valgrind would post a dozen use-after-free notices before that)

and bitlbee crashes before saving the new config, so I'm rejoined to the channel when bitlbee restarts.