### PR TITLE
Enforce space after emote URLs

### DIFF
--- a/src/discord-handlers.c
+++ b/src/discord-handlers.c
@@ -674,15 +674,15 @@ static gboolean discord_prepare_message(struct im_connection *ic,
     }
 
     // Replace animated emoji with code and a URL
-    GRegex *emoji_regex_a = g_regex_new("<a(:[^:]+:)(\\d+)> ?", 0, 0, NULL);
-    gchar *emoji_msg_a = g_regex_replace(emoji_regex_a, msg, -1, 0, "\\1 https://cdn.discordapp.com/emojis/\\2.gif ", 0, NULL);
+    GRegex *emoji_regex_a = g_regex_new("<a(:[^:]+:)(\\d+)>", 0, 0, NULL);
+    gchar *emoji_msg_a = g_regex_replace(emoji_regex_a, msg, -1, 0, "\\1 <https://cdn.discordapp.com/emojis/\\2.gif>", 0, NULL);
     g_free(msg);
     msg = emoji_msg_a;
     g_regex_unref(emoji_regex_a);
 
     // Replace custom emoji with code and a URL
-    GRegex *emoji_regex = g_regex_new("<(:[^:]+:)(\\d+)> ?", 0, 0, NULL);
-    gchar *emoji_msg = g_regex_replace(emoji_regex, msg, -1, 0, "\\1 https://cdn.discordapp.com/emojis/\\2.png ", 0, NULL);
+    GRegex *emoji_regex = g_regex_new("<(:[^:]+:)(\\d+)>", 0, 0, NULL);
+    gchar *emoji_msg = g_regex_replace(emoji_regex, msg, -1, 0, "\\1 <https://cdn.discordapp.com/emojis/\\2.png>", 0, NULL);
     g_free(msg);
     msg = emoji_msg;
     g_regex_unref(emoji_regex);

--- a/src/discord-handlers.c
+++ b/src/discord-handlers.c
@@ -674,15 +674,15 @@ static gboolean discord_prepare_message(struct im_connection *ic,
     }
 
     // Replace animated emoji with code and a URL
-    GRegex *emoji_regex_a = g_regex_new("<a(:[^:]+:)(\\d+)>", 0, 0, NULL);
-    gchar *emoji_msg_a = g_regex_replace(emoji_regex_a, msg, -1, 0, "\\1 https://cdn.discordapp.com/emojis/\\2.gif", 0, NULL);
+    GRegex *emoji_regex_a = g_regex_new("<a(:[^:]+:)(\\d+)> ?", 0, 0, NULL);
+    gchar *emoji_msg_a = g_regex_replace(emoji_regex_a, msg, -1, 0, "\\1 https://cdn.discordapp.com/emojis/\\2.gif ", 0, NULL);
     g_free(msg);
     msg = emoji_msg_a;
     g_regex_unref(emoji_regex_a);
 
     // Replace custom emoji with code and a URL
-    GRegex *emoji_regex = g_regex_new("<(:[^:]+:)(\\d+)>", 0, 0, NULL);
-    gchar *emoji_msg = g_regex_replace(emoji_regex, msg, -1, 0, "\\1 https://cdn.discordapp.com/emojis/\\2.png", 0, NULL);
+    GRegex *emoji_regex = g_regex_new("<(:[^:]+:)(\\d+)> ?", 0, 0, NULL);
+    gchar *emoji_msg = g_regex_replace(emoji_regex, msg, -1, 0, "\\1 https://cdn.discordapp.com/emojis/\\2.png ", 0, NULL);
     g_free(msg);
     msg = emoji_msg;
     g_regex_unref(emoji_regex);


### PR DESCRIPTION
Using the official client, say :thonk::thonk: in any channel.

Result: \<Alcaro> :thonk: https://cdn.discordapp.com/emojis/379295935689392148.png:thonk: https://cdn.discordapp.com/emojis/379295935689392148.png, where the :thonk is considered part of the URL, which makes it leads nowhere (some clients consider the final : part of the URL too, but that doesn't work either).

The simplest fix is this tweak to the emote regexes; regexes are greedy, so this won't emit duplicate spaces. It does yield an extra space at the end if a message ends with an emote, which can be avoided by doubling the number of regexes, but that's a bit of extra code for questionable gains. Your choice if it's worth it.