### PR TITLE
Add timestamp support

### DIFF
--- a/src/discord-handlers.h
+++ b/src/discord-handlers.h
@@ -24,7 +24,7 @@ typedef enum {
 } handler_action;
 
 void discord_handle_message(struct im_connection *ic, json_value *minfo,
-                            handler_action action, gboolean is_old);
+                            handler_action action, gboolean use_tstamp);
 void discord_handle_channel(struct im_connection *ic, json_value *cinfo,
                             const char *server_id, handler_action action);
 /* Returns TRUE if it called iwc_logout() */

--- a/src/discord-handlers.h
+++ b/src/discord-handlers.h
@@ -24,7 +24,7 @@ typedef enum {
 } handler_action;
 
 void discord_handle_message(struct im_connection *ic, json_value *minfo,
-                            handler_action action);
+                            handler_action action, gboolean is_old);
 void discord_handle_channel(struct im_connection *ic, json_value *cinfo,
                             const char *server_id, handler_action action);
 /* Returns TRUE if it called iwc_logout() */

--- a/src/discord-http.c
+++ b/src/discord-http.c
@@ -344,7 +344,7 @@ static void discord_http_backlog_cb(struct http_request *req)
 
     for (int midx = messages->u.array.length - 1; midx >= 0; midx--) {
       json_value *minfo = messages->u.array.values[midx];
-      discord_handle_message(ic, minfo, ACTION_CREATE);
+      discord_handle_message(ic, minfo, ACTION_CREATE, TRUE);
     }
 
     json_value_free(messages);
@@ -388,7 +388,7 @@ static void discord_http_pinned_cb(struct http_request *req)
 
     for (int midx = messages->u.array.length - 1; midx >= 0; midx--) {
       json_value *minfo = messages->u.array.values[midx];
-      discord_handle_message(ic, minfo, ACTION_CREATE);
+      discord_handle_message(ic, minfo, ACTION_CREATE, TRUE);
     }
 
     json_value_free(messages);

--- a/src/discord-util.c
+++ b/src/discord-util.c
@@ -385,8 +385,8 @@ char *discord_utf8_strndup(const char *str, size_t n)
 
 time_t parse_iso_8601(const char *timestamp)
 {
-	struct tm tm;
-	if (timestamp == NULL) return 0;
-	if (strptime(timestamp, "%Y-%m-%dT%H:%M:%S.", &tm) == NULL) return 0;
-	return mktime(&tm);
+  struct tm tm;
+  if (timestamp == NULL) return 0;
+  if (strptime(timestamp, "%Y-%m-%dT%H:%M:%S.", &tm) == NULL) return 0;
+  return mktime(&tm);
 }

--- a/src/discord-util.c
+++ b/src/discord-util.c
@@ -382,3 +382,11 @@ char *discord_utf8_strndup(const char *str, size_t n)
 
   return g_strndup(str, g_utf8_offset_to_pointer(str, n) - str);
 }
+
+time_t parse_iso_8601(const char *timestamp)
+{
+	struct tm tm;
+	if (timestamp == NULL) return 0;
+	if (strptime(timestamp, "%Y-%m-%dT%H:%M:%S.", &tm) == NULL) return 0;
+	return mktime(&tm);
+}

--- a/src/discord-util.c
+++ b/src/discord-util.c
@@ -385,8 +385,17 @@ char *discord_utf8_strndup(const char *str, size_t n)
 
 time_t parse_iso_8601(const char *timestamp)
 {
-  struct tm tm;
-  if (timestamp == NULL) return 0;
-  if (strptime(timestamp, "%Y-%m-%dT%H:%M:%S.", &tm) == NULL) return 0;
-  return mktime(&tm);
+#if GLIB_CHECK_VERSION(2,56,0)
+  if (!timestamp) return 0;
+  GDateTime *dt = g_date_time_new_from_iso8601(timestamp, NULL);
+  if (!dt) return 0;
+  gint64 unix = g_date_time_to_unix(dt);
+  g_date_time_unref(dt);
+  return unix;
+#else
+  GTimeVal gt;
+  if (!timestamp) return 0;
+  if (!g_time_val_from_iso8601(timestamp, &gt)) return 0;
+  return gt.tv_sec;
+#endif
 }

--- a/src/discord-util.h
+++ b/src/discord-util.h
@@ -17,6 +17,7 @@
 #include "discord.h"
 #include <stdlib.h>
 #include <glib.h>
+#include <time.h>
 
 typedef enum {
   SEARCH_UNKNOWN,
@@ -43,3 +44,7 @@ char *discord_canonize_name(const char *name);
 char *discord_escape_string(const char *msg);
 void discord_debug(char *format, ...);
 char *discord_utf8_strndup(const char *str, size_t n);
+
+/* input: 2018-05-24T19:06:42.190000+00:00 */
+/* output: 1527188802 (the .19 and timezone are discarded) */
+time_t parse_iso_8601(const char *timestamp);


### PR DESCRIPTION
Improves #152, but I wouldn't consider it fully fixed until bitlbee/bitlbee#98 (or equivalent) is done. Your choice if it's good enough that #152 can be closed.

strptime isn't part of the C standard library, but it is [part of POSIX](http://pubs.opengroup.org/onlinepubs/009695399/functions/strptime.html); since manual mentions 'sudo make install', I suspect non-Unix isn't supported. If that's incorrect, I can check if GLib contains a date parser, we already have a dependency on that.

Finally, bitlbee dev docs suck.