### PR TITLE
Compile as C99

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,7 +19,8 @@ lib_LTLIBRARIES = discord.la
 discord_la_CFLAGS  = \
 	$(BITLBEE_CFLAGS) \
 	$(GLIB_CFLAGS) \
-	-Wall
+	-Wall \
+	-std=c99
 
 discord_la_LDFLAGS = \
 	-module \


### PR DESCRIPTION
Fixes #156

The obvious fix would be renaming that variable, but adding -std=c99 instead has two advantages: It makes sure nobody else runs into similar traps later, and it improves compatibility with old compilers that default to -std=gnu89 and fail on variable declarations in for loops. (Modern GCCs default to -std=gnu11.)

Could use -std=c11 instead, but unless we're using C11 features, using C11 seems pointless.