### PR TITLE
Set away status

### DIFF
--- a/src/discord-websockets.c
+++ b/src/discord-websockets.c
@@ -420,9 +420,9 @@ void discord_ws_set_status(discord_data *dd, gchar *status, gchar *message)
     }
   } else {
     if (message != NULL) { // game
-      g_string_printf(buf, "{\"op\":%d,\"d\":{\"since\":null,\"game\":{\"name\":\"%s\",\"type\":0},\"afk\":true,\"status\":\"online\"}}", OPCODE_STATUS_UPDATE, msg);
+      g_string_printf(buf, "{\"op\":%d,\"d\":{\"since\":null,\"game\":{\"name\":\"%s\",\"type\":0},\"afk\":false,\"status\":\"online\"}}", OPCODE_STATUS_UPDATE, msg);
     } else { // default
-      g_string_printf(buf, "{\"op\":%d,\"d\":{\"since\":null,\"game\":null,\"afk\":true,\"status\":\"online\"}}", OPCODE_STATUS_UPDATE);
+      g_string_printf(buf, "{\"op\":%d,\"d\":{\"since\":null,\"game\":null,\"afk\":false,\"status\":\"online\"}}", OPCODE_STATUS_UPDATE);
     }
   }
 

--- a/src/discord-websockets.c
+++ b/src/discord-websockets.c
@@ -429,4 +429,5 @@ void discord_ws_set_status(discord_data *dd, gchar *status, gchar *message)
   discord_ws_send_payload(dd, buf->str, buf->len);
   g_string_free(buf, TRUE);
   g_free(msg);
+  g_free(stat);
 }

--- a/src/discord-websockets.c
+++ b/src/discord-websockets.c
@@ -27,7 +27,7 @@
 
 typedef struct {
   discord_data *dd;
-  gboolean idle;
+  gchar *status;
   gchar *msg;
 } status_data;
 
@@ -377,25 +377,27 @@ static gboolean discord_ws_status_postponed(status_data *sd, gint fd,
     return TRUE;
   }
 
-  discord_ws_set_status(sd->dd, sd->idle, sd->msg);
+  discord_ws_set_status(sd->dd, sd->status, sd->msg);
 
   g_free(sd->msg);
+  g_free(sd->status);
   g_free(sd);
   sd->dd->status_timeout_id = 0;
 
   return FALSE;
 }
 
-void discord_ws_set_status(discord_data *dd, gboolean idle, gchar *message)
+void discord_ws_set_status(discord_data *dd, gchar *status, gchar *message)
 {
   GString *buf = g_string_new("");
   gchar *msg = NULL;
+  gchar *stat = NULL;
 
   if (dd->state != WS_READY) {
     if (dd->status_timeout_id == 0) {
       status_data *sdata = g_new0(status_data, 1);
       sdata->dd = dd;
-      sdata->idle = idle;
+      sdata->status = g_strdup(status);
       sdata->msg = g_strdup(message);
       dd->status_timeout_id = b_timeout_add(DISCORD_STATUS_TIMEOUT,
         (b_event_handler)discord_ws_status_postponed, sdata);
@@ -406,14 +408,24 @@ void discord_ws_set_status(discord_data *dd, gboolean idle, gchar *message)
   if (message != NULL) {
     msg = discord_escape_string(message);
   }
-
-  if (idle == TRUE) {
-    g_string_printf(buf, "{\"op\":%d,\"d\":{\"since\":%llu,\"game\":{\"name\":\"%s\",\"type\":0},\"afk\":true,\"status\":\"idle\"}}", OPCODE_STATUS_UPDATE, ((unsigned long long)time(NULL))*1000, msg);
-  } else if (message != NULL) {
-    g_string_printf(buf, "{\"op\":%d,\"d\":{\"since\":null,\"game\":{\"name\":\"%s\",\"type\":0},\"afk\":false,\"status\":\"online\"}}", OPCODE_STATUS_UPDATE, msg);
-  } else {
-    g_string_printf(buf, "{\"op\":%d,\"d\":{\"since\":null,\"game\":null,\"afk\":false,\"status\":\"online\"}}", OPCODE_STATUS_UPDATE);
+  if (status != NULL) {
+    stat = discord_escape_string(status);
   }
+
+  if (status != NULL) {
+    if (message != NULL) { // game and away
+      g_string_printf(buf, "{\"op\":%d,\"d\":{\"since\":%llu,\"game\":{\"name\":\"%s\",\"type\":0},\"afk\":false,\"status\":\"%s\"}}", OPCODE_STATUS_UPDATE, ((unsigned long long)time(NULL))*1000, msg, stat);
+    } else { // away
+      g_string_printf(buf, "{\"op\":%d,\"d\":{\"since\":%llu,\"game\":null,\"afk\":false,\"status\":\"%s\"}}", OPCODE_STATUS_UPDATE, ((unsigned long long)time(NULL))*1000, stat);
+    }
+  } else {
+    if (message != NULL) { // game
+      g_string_printf(buf, "{\"op\":%d,\"d\":{\"since\":null,\"game\":{\"name\":\"%s\",\"type\":0},\"afk\":false,\"status\":\"online\"}}", OPCODE_STATUS_UPDATE, msg);
+    } else { // default
+      g_string_printf(buf, "{\"op\":%d,\"d\":{\"since\":null,\"game\":null,\"afk\":false,\"status\":\"online\"}}", OPCODE_STATUS_UPDATE);
+    }
+  }
+
   discord_ws_send_payload(dd, buf->str, buf->len);
   g_string_free(buf, TRUE);
   g_free(msg);

--- a/src/discord-websockets.c
+++ b/src/discord-websockets.c
@@ -414,15 +414,15 @@ void discord_ws_set_status(discord_data *dd, gchar *status, gchar *message)
 
   if (status != NULL) {
     if (message != NULL) { // game and away
-      g_string_printf(buf, "{\"op\":%d,\"d\":{\"since\":%llu,\"game\":{\"name\":\"%s\",\"type\":0},\"afk\":false,\"status\":\"%s\"}}", OPCODE_STATUS_UPDATE, ((unsigned long long)time(NULL))*1000, msg, stat);
+      g_string_printf(buf, "{\"op\":%d,\"d\":{\"since\":%llu,\"game\":{\"name\":\"%s\",\"type\":0},\"afk\":true,\"status\":\"%s\"}}", OPCODE_STATUS_UPDATE, ((unsigned long long)time(NULL))*1000, msg, stat);
     } else { // away
-      g_string_printf(buf, "{\"op\":%d,\"d\":{\"since\":%llu,\"game\":null,\"afk\":false,\"status\":\"%s\"}}", OPCODE_STATUS_UPDATE, ((unsigned long long)time(NULL))*1000, stat);
+      g_string_printf(buf, "{\"op\":%d,\"d\":{\"since\":%llu,\"game\":null,\"afk\":true,\"status\":\"%s\"}}", OPCODE_STATUS_UPDATE, ((unsigned long long)time(NULL))*1000, stat);
     }
   } else {
     if (message != NULL) { // game
-      g_string_printf(buf, "{\"op\":%d,\"d\":{\"since\":null,\"game\":{\"name\":\"%s\",\"type\":0},\"afk\":false,\"status\":\"online\"}}", OPCODE_STATUS_UPDATE, msg);
+      g_string_printf(buf, "{\"op\":%d,\"d\":{\"since\":null,\"game\":{\"name\":\"%s\",\"type\":0},\"afk\":true,\"status\":\"online\"}}", OPCODE_STATUS_UPDATE, msg);
     } else { // default
-      g_string_printf(buf, "{\"op\":%d,\"d\":{\"since\":null,\"game\":null,\"afk\":false,\"status\":\"online\"}}", OPCODE_STATUS_UPDATE);
+      g_string_printf(buf, "{\"op\":%d,\"d\":{\"since\":null,\"game\":null,\"afk\":true,\"status\":\"online\"}}", OPCODE_STATUS_UPDATE);
     }
   }
 

--- a/src/discord-websockets.h
+++ b/src/discord-websockets.h
@@ -37,5 +37,5 @@ gboolean discord_ws_keepalive_loop(gpointer data, gint fd,
 
 int discord_ws_init(struct im_connection *ic, discord_data *dd);
 void discord_ws_cleanup(discord_data *dd);
-void discord_ws_set_status(discord_data *dd, gboolean idle, gchar *message);
+void discord_ws_set_status(discord_data *dd, gchar *status, gchar *message);
 void discord_ws_sync_server(discord_data *dd, const char *id);

--- a/src/discord.c
+++ b/src/discord.c
@@ -286,10 +286,10 @@ static GList *discord_away_states(struct im_connection *ic)
 {
     static GList *m = NULL;
 
-    m = g_list_append(m, "online");
-    m = g_list_append(m, "idle");
-    m = g_list_append(m, "dnd");
-    m = g_list_append(m, "invisible");
+    m = g_list_prepend(m, "invisible");
+    m = g_list_prepend(m, "dnd");
+    m = g_list_prepend(m, "idle");
+    m = g_list_prepend(m, "online");
 
     return m;
 }

--- a/src/discord.c
+++ b/src/discord.c
@@ -286,7 +286,10 @@ static GList *discord_away_states(struct im_connection *ic)
 {
     static GList *m = NULL;
 
-    m = g_list_append(m, "Idle");
+    m = g_list_append(m, "online");
+    m = g_list_append(m, "idle");
+    m = g_list_append(m, "dnd");
+    m = g_list_append(m, "invisible");
 
     return m;
 }
@@ -296,7 +299,7 @@ static void discord_set_away(struct im_connection *ic, char *state,
 {
   discord_data *dd = ic->proto_data;
 
-  discord_ws_set_status(dd, state != NULL, message);
+  discord_ws_set_status(dd, state, message);
 }
 
 G_MODULE_EXPORT void init_plugin(void)


### PR DESCRIPTION
You can set your discord status to 'online', 'dnd', 'idle', or 'invisible' via `away` variable's value.

**Known issues**: 
- bitlbee seems to discard `status` variable's value (`msg`, `message` in the code) if `away` variable is not empty. This mean's you can't change what your "current game" is unless you have your away status empty.
- ~~`"afk": true` means you should receive push notifications regardless of away status.~~
- People using Quassel might have away status not set to "Idle" when the plugin is provided with a nonstandard away value. (#25)?

These changes are experimental, feel free to suggest feedback before merging to mainline.