### PR TITLE
imcb_add_buddy is slow, let's not

### DIFF
--- a/src/discord-handlers.c
+++ b/src/discord-handlers.c
@@ -144,7 +144,7 @@ static void discord_handle_user(struct im_connection *ic, json_value *uinfo,
       bee_user_t *bu = bee_user_by_handle(ic->bee, ic, name);
 
       if (bu == NULL) {
-        imcb_add_buddy(ic, name, NULL);
+        bu = bee_user_new(ic->bee, ic, name, 0);
         if (set_getbool(&ic->acc->set, "never_offline") == TRUE) {
           flags = BEE_USER_ONLINE | BEE_USER_AWAY;
           if (set_getbool(&ic->acc->set, "friendship_mode") == FALSE) {
@@ -153,7 +153,6 @@ static void discord_handle_user(struct im_connection *ic, json_value *uinfo,
         } else {
           imcb_buddy_status(ic, name, 0, NULL, NULL);
         }
-        bu = bee_user_by_handle(ic->bee, ic, name);
       }
 
       if (bu != NULL) {


### PR DESCRIPTION
This should improve #159, but is not a complete fix.

Full details: [bee_user_by_handle is slow.](https://github.com/bitlbee/bitlbee/blob/7801298f6a855cda0c62433d45ec717d2773ef73/protocols/bee_user.c#L82) It traverses a linked list of all users, doing string comparison for each; with one call per discord_handle_user, with 10000 users, yields 10000^2/2 = 50 million string comparisons.

In practice, there are three such calls. To solve #159, we must remove them. Two are direct, the third is [via imcb_add_buddy](https://github.com/bitlbee/bitlbee/blob/2b6cb873a5848cbb3ab204da9d0d84970764128f/protocols/nogaim.c#L564).

Two are easy to remove. With group NULL and user known to not exist already, imcb_add_buddy does nothing except call bee_user_new, so let's do that directly. This also gives us the bee_user_t*, so the last bee_user_by_handle disappears too (though that lookup takes negligible time, since that user is the head of the list).

I expect this PR should reduce the login time to roughly half. @Corosauce, try it.

If this acts as expected, the next step is removing the last call. This is a fair bit more code (we probably need a GHashTable of users), so we should take the easy one first; if it does not yield the expected result, we have to examine the issue further and find another solution.