### PR TITLE
discord_canonize_name: Use str_reject_chars from bitlbee instead of a regex

### DIFF
--- a/src/discord-util.c
+++ b/src/discord-util.c
@@ -329,11 +329,7 @@ user_info *get_user(discord_data *dd, const char *uname,
 
 char *discord_canonize_name(const char *name)
 {
-  GRegex *regex = g_regex_new("[@+ ]", 0, 0, NULL);
-  char *cname = g_regex_replace_literal(regex, name, -1, 0, "_", 0, NULL);
-
-  g_regex_unref(regex);
-  return cname;
+  return str_reject_chars(g_strdup(name), "@+ ", '_');
 }
 
 static gboolean discord_escape(const GMatchInfo *match, GString *result,


### PR DESCRIPTION
Going backwards through the list of optimizations applied - this is the last one, only meaningful after applying a bunch of others. It's also trivial so, worth splitting.

See the left side of this:

![ql-8_](https://user-images.githubusercontent.com/94108/42199701-47207be4-7e66-11e8-822e-3e0868668ae5.png)
