### PR TITLE
Use guint64 to store user ids, speeds up get_user(...SEARCH_ID)

### DIFF
--- a/src/discord-http.c
+++ b/src/discord-http.c
@@ -427,7 +427,7 @@ static gboolean discord_mentions_string(const GMatchInfo *match,
   g_free(name);
 
   if (uinfo != NULL) {
-    gchar *id = g_strdup_printf("<@%s>", uinfo->id);
+    gchar *id = g_strdup_printf("<@%" G_GUINT64_FORMAT ">", uinfo->id);
     result = g_string_append(result, id);
     g_free(id);
   } else {
@@ -678,8 +678,8 @@ void discord_http_create_and_send_msg(struct im_connection *ic,
   GString *request = g_string_new("");
   GString *content = g_string_new("");
 
-  g_string_printf(content, "{\"recipient_id\":\"%s\"}", uinfo->id);
-  g_string_printf(request, "POST /api/users/%s/channels HTTP/1.1\r\n"
+  g_string_printf(content, "{\"recipient_id\":\"%" G_GUINT64_FORMAT "\"}", uinfo->id);
+  g_string_printf(request, "POST /api/users/%" G_GUINT64_FORMAT "/channels HTTP/1.1\r\n"
                   "Host: %s\r\n"
                   "User-Agent: Bitlbee-Discord\r\n"
                   "authorization: %s\r\n"

--- a/src/discord-util.c
+++ b/src/discord-util.c
@@ -42,7 +42,6 @@ void discord_debug(char *format, ...)
 void free_user_info(user_info *uinfo)
 {
   g_free(uinfo->name);
-  g_free(uinfo->id);
   g_free(uinfo);
 }
 
@@ -123,7 +122,6 @@ void free_discord_data(discord_data *dd)
   g_free(dd->token);
   g_free(dd->uname);
   g_free(dd->session_id);
-  g_free(dd->id);
 
   g_free(dd);
 }
@@ -179,9 +177,9 @@ static gint cmp_chan_name_ignorecase(const channel_info *cinfo,
   return result;
 }
 
-static gint cmp_user_id(const user_info *uinfo, const char *user_id)
+static gint cmp_user_id(const user_info *uinfo, guint64 *user_id)
 {
-  return g_strcmp0(uinfo->id, user_id);
+  return uinfo->id == *user_id;
 }
 
 static gint cmp_user_name(const user_info *uinfo, const char *uname)

--- a/src/discord.h
+++ b/src/discord.h
@@ -55,7 +55,7 @@ typedef struct _gw_data {
 
 typedef struct _discord_data {
   char     *token;
-  char     *id;
+  guint64  id;
   char     *session_id;
   char     *uname;
   char     *nonce;
@@ -116,7 +116,7 @@ typedef struct _channel_info {
 } channel_info;
 
 typedef struct _user_info {
-  char                 *id;
+  guint64              id;
   char                 *name;
   channel_info         *voice_channel;
   bee_user_t           *user;


### PR DESCRIPTION
Second to last of today's optimizations, also probably not as meaningful as linked list tweaks in bitlbee, but it brought a guild sync of 50k members from 162 to 13 seconds (inside callgrind, which slows everything down. I don't know the time for that guild inside callgrind without any optimizations, probably 10 or 20 minutes)

Callgraph that motivated this change follows. `cmp_user_id` and its corresponding `g_slist_find_custom` both pretty much vanish after applying this. I expected needing to get rid of linked lists in here too, but it doesn't look like it will be necessary (eion says that he has hash tables for everything in )

![vbkh4](https://user-images.githubusercontent.com/94108/42199863-22b44a14-7e67-11e8-9ddd-b88a6a4f1c95.png)
