### PR TITLE
Let's tell what message failed to send

### DIFF
--- a/src/discord-http.c
+++ b/src/discord-http.c
@@ -317,7 +317,12 @@ static void discord_http_send_msg_cb(struct http_request *req)
 
   if (req->status_code != 200) {
     if (discord_http_check_retry(req) == 0) {
-      imcb_error(ic, "Failed to send message (%d).", req->status_code);
+      char *json_text = strstr(req->request, "{\"content\":\"");
+      json_value *js = json_parse(json_text, strlen(json_text));
+      const char *message = json_o_str(js, "content");
+      
+      imcb_error(ic, "Failed to send message (%d; %s).", req->status_code, message);
+      json_value_free(js);
     }
   }
 }


### PR DESCRIPTION
After seeing this error, I've often found myself opening the other client and checking all over for what messages I've sent and whether any is missing (half of the time, it's none of them; discord often delivers the message, but returns some random error over http. I suspect this is what causes all those duplicate messages on the other client).

Let's simplify that by telling which message is relevant.

This doesn't tell what channel it's for, and leaves `<@12345678>`/etc in there. This can be fixed later, but let's start simple; this is sufficient to allow identifying which message is screwing up and verifying whether it arrived.

(also yes, that strstr is ugly. I'd be glad to replace it with something else, but I couldn't find anything better.)