### PR TITLE
Added fixes for crashing upon somebody removing you from their friends.

### DIFF
--- a/src/discord-handlers.c
+++ b/src/discord-handlers.c
@@ -196,7 +196,7 @@ static void discord_handle_relationship(struct im_connection *ic, json_value *ri
   if(action == ACTION_DELETE) {
     user_info *uinf = get_user(dd, json_o_str(rinfo, "id"), NULL, SEARCH_ID);
     name = discord_canonize_name(uinf->name);
-    bu = uinf->user
+    bu = uinf->user;
   } else {
     json_value *uinfo = json_o_get(rinfo, "user");
     name = discord_canonize_name(json_o_str(uinfo, "username"));

--- a/src/discord-handlers.c
+++ b/src/discord-handlers.c
@@ -1,3 +1,4 @@
+    json_value *uinfo = json_o_get(rinfo, "user");
 /*
  * Copyright 2015-2016 Artem Savkov <artem.savkov@gmail.com>
  *

--- a/src/discord-handlers.c
+++ b/src/discord-handlers.c
@@ -191,6 +191,7 @@ static void discord_handle_relationship(struct im_connection *ic, json_value *ri
   discord_data *dd = ic->proto_data;
   relationship_type rtype = 0;
   char *name = NULL;
+  json_value *uinfo = NULL;
   bee_user_t *bu = NULL;
 
   if(action == ACTION_DELETE) {
@@ -198,7 +199,7 @@ static void discord_handle_relationship(struct im_connection *ic, json_value *ri
     name = discord_canonize_name(uinf->name);
     bu = uinf->user;
   } else {
-    json_value *uinfo = json_o_get(rinfo, "user");
+    uinfo = json_o_get(rinfo, "user");
     name = discord_canonize_name(json_o_str(uinfo, "username"));
     bu = bee_user_by_handle(ic->bee, ic, name);
   }

--- a/src/discord-handlers.c
+++ b/src/discord-handlers.c
@@ -1,4 +1,3 @@
-    json_value *uinfo = json_o_get(rinfo, "user");
 /*
  * Copyright 2015-2016 Artem Savkov <artem.savkov@gmail.com>
  *
@@ -192,18 +191,19 @@ static void discord_handle_relationship(struct im_connection *ic, json_value *ri
   discord_data *dd = ic->proto_data;
   relationship_type rtype = 0;
   char *name = NULL;
-  json_value *uinfo = NULL;
+  bee_user_t *bu = NULL;
 
   if(action == ACTION_DELETE) {
     user_info *uinf = get_user(dd, json_o_str(rinfo, "id"), NULL, SEARCH_ID);
     name = discord_canonize_name(uinf->name);
+    bu = uinf->user
   } else {
-    uinfo = json_o_get(rinfo, "user");
+    json_value *uinfo = json_o_get(rinfo, "user");
     name = discord_canonize_name(json_o_str(uinfo, "username"));
+    bu = bee_user_by_handle(ic->bee, ic, name);
   }
   json_value *tjs = json_o_get(rinfo, "type");
-  bee_user_t *bu = bee_user_by_handle(ic->bee, ic, name);
-
+  
   if (action == ACTION_CREATE) {
     rtype = (tjs && tjs->type == json_integer) ? tjs->u.integer : 0;
 

--- a/src/discord-handlers.c
+++ b/src/discord-handlers.c
@@ -190,9 +190,17 @@ static void discord_handle_relationship(struct im_connection *ic, json_value *ri
 {
   discord_data *dd = ic->proto_data;
   relationship_type rtype = 0;
-  json_value *uinfo = json_o_get(rinfo, "user");
+  char *name = NULL;
+  json_value *uinfo = NULL;
+
+  if(action == ACTION_DELETE) {
+    user_info *uinf = get_user(dd, json_o_str(rinfo, "id"), NULL, SEARCH_ID);
+    name = discord_canonize_name(uinf->name);
+  } else {
+    uinfo = json_o_get(rinfo, "user");
+    name = discord_canonize_name(json_o_str(uinfo, "username"));
+  }
   json_value *tjs = json_o_get(rinfo, "type");
-  char *name = discord_canonize_name(json_o_str(uinfo, "username"));
   bee_user_t *bu = bee_user_by_handle(ic->bee, ic, name);
 
   if (action == ACTION_CREATE) {


### PR DESCRIPTION
Before these fixes, RELATIONSHIP_REMOVE would cause a segfault. My understanding of this, is that RELATIONSHIP_REMOVE's json looks like: `{"t":"RELATIONSHIP_REMOVE","s":97,"op":0,"d":{"type":1,"id":"<removed>"}}` and this is the primary cause of this problem.

In the original code, `json_value *uinfo = json_o_get(rinfo, "user");` would lead to a null pointer being fed into discord_canonize_name as `char *name = discord_canonize_name(json_o_str(uinfo, "username"));` has no handling for being fed a null pointer. This then causes a segmentation fault, as follows:

```
Program received signal SIGSEGV, Segmentation fault.
0x000055555558cd4b in str_reject_chars (string=0x0, reject=0x7ffff7fc90c6 "@+ ", replacement=95 '_') at misc.c:741
741		while (*c) {
#0  0x000055555558cd4b in str_reject_chars (string=0x0, reject=0x7ffff7fc90c6 "@+ ", replacement=95 '_') at misc.c:741
#1  0x00007ffff7fc1bea in ?? () from /usr/local/lib/bitlbee/discord.so
#2  0x00007ffff7fc41b3 in discord_parse_message () from /usr/local/lib/bitlbee/discord.so
#3  0x00007ffff7fc6826 in ?? () from /usr/local/lib/bitlbee/discord.so
#4  0x00005555555862e7 in gaim_io_invoke (source=0x555555657a70, condition=G_IO_IN, data=0x55555566a0e0) at events_glib.c:86
#5  0x00007ffff793e1d6 in g_main_context_dispatch () from /usr/lib/libglib-2.0.so.0
#6  0x00007ffff793e5b1 in ?? () from /usr/lib/libglib-2.0.so.0
#7  0x00007ffff793e8e2 in g_main_loop_run () from /usr/lib/libglib-2.0.so.0
#8  0x0000555555586257 in b_main_run () at events_glib.c:59
#9  0x0000555555583100 in main (argc=4, argv=0x7fffffffe588) at unix.c:196
(gdb)
```

Instead of adding in specific null pointer handling, I reworked it to get the ID from the request and to use get_user to get the user from that, instead. This is probably a messy fix and a better fix would be to break up discord_handle_relationship into more than one function and handle each seperately.