### PR TITLE
Fixed crashing problems upon rejecting more than one friend request.

### DIFF
--- a/src/discord-handlers.c
+++ b/src/discord-handlers.c
@@ -193,6 +193,7 @@ static void discord_handle_relationship(struct im_connection *ic, json_value *ri
   char *name = NULL;
   json_value *uinfo = NULL;
   bee_user_t *bu = NULL;
+  user_info *uinf = NULL;
   json_value *tjs = json_o_get(rinfo, "type");
 
   if (action == ACTION_CREATE) {
@@ -209,7 +210,7 @@ static void discord_handle_relationship(struct im_connection *ic, json_value *ri
       if (bu) {
         bu->data = GINT_TO_POINTER(TRUE);
         if (set_getbool(&ic->acc->set, "friendship_mode") == TRUE) {
-          user_info *uinf = get_user(dd, name, NULL, SEARCH_NAME);
+          uinf = get_user(dd, name, NULL, SEARCH_NAME);
           imcb_buddy_status(ic, name, uinf->flags, NULL, NULL);
         }
       }
@@ -218,17 +219,17 @@ static void discord_handle_relationship(struct im_connection *ic, json_value *ri
     }
 
   } else if (action == ACTION_DELETE) {
-    user_info *uinf = get_user(dd, json_o_str(rinfo, "id"), NULL, SEARCH_ID);
-    name = g_strdup(uinf->name);
-    bu = uinf->user;
-    if (bu) {
+    uinf =  get_user(dd, json_o_str(rinfo, "id"), NULL, SEARCH_ID);
+    
+    if (uinf && uinf->user) {
+      bu = uinf->user;
+      name = g_strdup(uinf->name);
       bu->data = GINT_TO_POINTER(FALSE);
       if (set_getbool(&ic->acc->set, "friendship_mode") == TRUE) {
         imcb_buddy_status(ic, name, 0, NULL, NULL);
       }
     }
   }
-
   g_free(name);
 }
 


### PR DESCRIPTION
I think this is caused by uinf and uinf->user being a null pointer. Not really sure why that is, but this fixes the crash that would otherwise cause. I imagine it's because the user has never actually existed within the bitlbee user list and therefore doesn't need updating, but the real question is why it works for the first rejection but not the second.

I also slightly cleaned it up so uinf is defined before usage in either case, meaning there's only one definition statement.

```
Program received signal SIGSEGV, Segmentation fault.
discord_handle_relationship (ic=0x5555557fab50, rinfo=0x5555558121d0, action=ACTION_DELETE) at discord-handlers.c:223
223	    name = g_strdup_printf(uinf->name);
#0  discord_handle_relationship (ic=0x5555557fab50, rinfo=0x5555558121d0, action=ACTION_DELETE) at discord-handlers.c:223
#1  0x00007ffff4aa859a in discord_parse_message (ic=ic@entry=0x5555557fab50, 
    buf=buf@entry=0x555555859f30 "{\"t\":\"RELATIONSHIP_REMOVE\",\"s\":11,\"op\":0,\"d\":{\"type\":3,\"id\":\"<removed>\"}}", size=size@entry=82)
    at discord-handlers.c:998
#2  0x00007ffff4aaaa89 in discord_ws_in_cb (data=0x5555557fab50, source=12, cond=B_EV_IO_READ) at discord-websockets.c:282
#3  0x000055555557c661 in b_event_passthrough (fd=12, event=<optimized out>, data=0x555555812050) at ./lib/events_libevent.c:143
#4  0x00007ffff73845a0 in event_base_loop () from /usr/lib/x86_64-linux-gnu/libevent-2.0.so.5
#5  0x000055555557c1e0 in b_main_run () at ./lib/events_libevent.c:84
#6  0x00005555555659bc in main (argc=<optimized out>, argv=0x7fffffffe618) at ./unix.c:196
(gdb) 
```