### PR TITLE
Set user real name to untouched nickname

### DIFF
--- a/src/discord-handlers.c
+++ b/src/discord-handlers.c
@@ -145,6 +145,7 @@ static void discord_handle_user(struct im_connection *ic, json_value *uinfo,
 
       if (bu == NULL) {
         imcb_add_buddy(ic, name, NULL);
+        imcb_rename_buddy(ic, name, json_o_str(uinfo, "username"));
         if (set_getbool(&ic->acc->set, "never_offline") == TRUE) {
           flags = BEE_USER_ONLINE | BEE_USER_AWAY;
           if (set_getbool(&ic->acc->set, "friendship_mode") == FALSE) {


### PR DESCRIPTION
Users' true (global) names will be available in WHOIS output and in clients that display real names in the chat view, etc.

This is the result of about an hour (maybe 90 minutes?) reading code, trying to understand how BitlBee and the Discord plugin create/maintain users. I think I ultimately found the right place to do this. It compiled & ran nicely on my test Discord account, on my local system, displaying real names in HexChat with all Unicode characters, whitespace, and other nonsense included. (I joined my test account to a fairly large server with ~200 users, many of whom have Discord usernames that BitlBee currently turns into underscore soup.)

This change technically closes #155, assuming it all checks out. I will next look at changing the reported ident as suggested there, if that's desired, either in this PR or a new one. This has been a good way to dip my toes in the waters of actually working on some BitlBee stuff, and I hope to continue learning.