### PR TITLE
websocket: Lowercase "status" state to fix aliases

### DIFF
--- a/src/discord-websockets.c
+++ b/src/discord-websockets.c
@@ -445,7 +445,11 @@ void discord_ws_set_status(struct im_connection *ic, gchar *status,
     msg = discord_escape_string(message);
   }
   if (status != NULL) {
-    stat = discord_escape_string(status);
+    // HACK: Discord requires lowercase 'status' states
+    // Bitlbee's alias matching currently gives "DND" for "Busy", so lowercase it
+    gchar *status_lower = g_ascii_strdown(status, -1);
+    stat = discord_escape_string(status_lower);
+    g_free(status_lower);
   }
 
   if (status != NULL) {


### PR DESCRIPTION
## In brief
* Lowercase `status` state provided by Bitlbee
  * Fixes handling aliases, e.g. `/away Busy - reason` → `"status":"dnd"`
  * Previously, `/away Busy - reason` → `"status":"DND"`, which Discord ignored

## Details
Lowercase the `status` state provided by Bitlbee to fix handling aliases.

Doing `/away DND - test` would give `dnd`, but `/away Busy - test` would give `DND` from the alias list.

See [sm00th's comment with a self-contained example](https://github.com/sm00th/bitlbee-discord/issues/229#issuecomment-1004638320 ):

```
$ ./imc_away_state_find "Busy - resting after trip"
away=DND
$ ./imc_away_state_find "DND - resting after trip"
away=dnd
```


### Bitlbee plugin API
@dequis In the future, Bitlbee may want to change `imc_away_state_find` to match case with the plugin's provided away states?

If so, `bitlbee-discord` may want to keep this patch for some time until new Bitlbee versions have rolled out across distros.

## Test case
### Steps
1.  Run Bitlbee with debugging information
     * `sudo --user=bitlbee BITLBEE_DEBUG=1 bitlbee -nvD`
2.  Connect
3.  Clear any `/away` status (in Quassel IRC, use `/back`)
4.  Run `/away DND - test`, observe results
5.  Clear `/away` status
6.  Run `/away Busy - test`, observe results

### Before
`/away Busy - test`

```
[16:04:03] >>> (digitalcircuit) discord_ws_send_payload 166
{"op":3,"d":{"since":1641330243000,"game":{"name":"Busy - test","type":0},"afk":true,"status":"DND"}}

[16:04:03] <<< (digitalcircuit) discord_parse_message 1209
{"t":"GUILD_MEMBER_LIST_UPDATE","s":102,"op":0,"d":{"ops":[{"op":"UPDATE","item":…"presence":{"user":{"id":"…"},"status":"online","game":{"type":0,"session_id":null,"name":"Busy - test","id":"e78eefaaab722356","created_at":1641330243900},"client_status":{"web":"online"},"activities":[{"type":0,"name":"Busy - test","id":"e78eefaaab722356","created_at":1641330243900},…]}}
```

`"status":"DND"` → `"client_status":{"web":"online"}`

### After
`/away Busy - test`

```
[16:42:53] >>> (digitalcircuit) discord_ws_send_payload 115
{"op":3,"d":{"since":1641332573000,"game":{"name":"Busy - test","type":0},"afk":true,"status":"dnd"}}

[16:42:53] <<< (digitalcircuit) discord_parse_message 954
{"t":"GUILD_MEMBER_LIST_UPDATE","s":148,"op":0,"d":{"ops":[{"op":"UPDATE","item":{"presence":{"user":{"status":"dnd","game":{"type":0,"session_id":null,"name":"Busy - test","id":"e1d494c83a244256","created_at":1641332573548},"client_status":{"web":"dnd"},"activities":[{"type":0,"name":"Busy - test","id":"e1d494c83a244256","created_at":1641332573548}]}]}}
```

`"status":"dnd"` → `"client_status":{"web":"dnd"}`